### PR TITLE
Add collision validator regression tests and refresh roadmap

### DIFF
--- a/docs/dev/MILESTONE_ROADMAP.md
+++ b/docs/dev/MILESTONE_ROADMAP.md
@@ -15,7 +15,7 @@ This document outlines the key milestones for turning the AndoSim physics engine
 - [~] Expose core physics parameters in Blender:
   - [x] Time stepping & solver controls (dt, β, Newton/PCG).
   - [x] Material properties (E, ν, density, thickness).
-  - [ ] Damping & restitution presets (pending material system).
+  - [ ] Damping & restitution presets (material presets ready; needs solver/parameter support).
 - [x] Enable single-frame simulation preview in the viewport (Step operator + realtime modal).
 - [~] Ensure correct unit scaling and axis alignment with Blender.
   - Z-up alignment handled; scaling audit still queued for validation pass.
@@ -25,27 +25,27 @@ This document outlines the key milestones for turning the AndoSim physics engine
 ## Phase 2: Reliability and Visual Feedback
 **Goal:** Make the simulation visually stable and understandable in the Blender viewport.
 
-- [ ] Continuous collision validation (no intersections, even for fast-moving objects).  
-  _Next:_ CCD hooks exist in core; expose toggles & add regression tests.
+- [x] Continuous collision validation (no intersections, even for fast-moving objects).
+  _Status:_ CCD toggles are exposed, metrics surface in the UI, and regression tests cover validator metrics.
 - [ ] Smooth elastic responses:
   - Visually accurate bounces.
   - Stable stacks and dense contacts.
-- [~] Real-time parameter feedback:
+- [x] Real-time parameter feedback:
   - [x] Sliders for stiffness, friction, solver tolerances.
-  - [ ] Immediate viewport response for parameter edits mid-sim (requires re-init hooks).
+  - [x] Immediate viewport response for parameter edits mid-sim (hot-reload operator updates params in-place).
 - [x] Debug overlays:
   - [x] Contact points, normals (type-colored) and pins visualized in viewport.
-  - [ ] Energy drift / constraint violation visualization.
+  - [x] Energy drift / constraint violation visualization.
 
 ---
 
 ## Phase 3: Usability and Workflow
 **Goal:** Make AndoSim intuitive and easy to use within typical Blender workflows.
 
-- [ ] Panel and UI design:
-  - Group parameters logically.
-  - Presets for common materials (metal, rubber, jelly, etc.).
-- [ ] Keyframe integration:
+- [x] Panel and UI design:
+  - [x] Group parameters logically.
+  - [x] Presets for common materials (metal, rubber, jelly, etc.).
+- [x] Keyframe integration:
   - Bake AndoSim simulations to Blender keyframes for animation.
 - [ ] Scene save/load support:
   - Persist AndoSim-specific simulation states across Blender sessions.
@@ -55,9 +55,9 @@ This document outlines the key milestones for turning the AndoSim physics engine
 ---
 
 ### Current Focus
-- Material preset system (rubber, metal, cloth, jelly) powering solver parameters.
-- Collision validation pass to surface CCD/debug metrics in the UI.
-- Documentation refresh once Phase 2 reliability work lands.
+- Damping & restitution parameter wiring for presets and solver hooks.
+- Smooth elastic response tuning and dense contact stability tests.
+- Documentation refresh now that Phase 2 reliability features are in place.
 
 ---
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,3 +37,17 @@ target_include_directories(test_barrier_derivatives PRIVATE
 
 # Register barrier test
 add_test(NAME BarrierDerivativesTest COMMAND test_barrier_derivatives)
+
+# Collision validator metrics tests
+add_executable(test_collision_validator
+    test_collision_validator.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/collision_validator.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/mesh.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/state.cpp
+)
+target_include_directories(test_collision_validator PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${EIGEN3_INCLUDE_DIR}
+)
+
+add_test(NAME CollisionValidatorTest COMMAND test_collision_validator)

--- a/tests/test_collision_validator.cpp
+++ b/tests/test_collision_validator.cpp
@@ -1,0 +1,139 @@
+#include "../src/core/collision_validator.h"
+#include "../src/core/mesh.h"
+#include "../src/core/state.h"
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+using namespace ando_barrier;
+
+namespace {
+
+void initialize_simple_mesh(Mesh& mesh, State& state) {
+    std::vector<Vec3> vertices = {
+        Vec3(0.0, 0.0, 0.0),
+        Vec3(1.0, 0.0, 0.0),
+        Vec3(0.0, 0.0, 1.0),
+        Vec3(1.0, 0.0, 1.0)
+    };
+
+    std::vector<Triangle> triangles = {
+        Triangle(0, 1, 2),
+        Triangle(1, 3, 2)
+    };
+
+    Material material;
+    mesh.initialize(vertices, triangles, material);
+    state.initialize(mesh);
+}
+
+void test_empty_contact_metrics() {
+    std::cout << "Testing collision metrics with no contacts..." << std::endl;
+
+    Mesh mesh;
+    State state;
+    initialize_simple_mesh(mesh, state);
+
+    std::vector<ContactPair> contacts;
+    CollisionMetrics metrics = CollisionValidator::compute_metrics(
+        mesh, state, contacts, /*gap_max=*/0.002f, /*ccd_enabled=*/true);
+
+    assert(metrics.num_total_contacts == 0);
+    assert(metrics.num_penetrations == 0);
+    assert(metrics.is_stable);
+    assert(metrics.ccd_effectiveness == 0.0f);
+    assert(metrics.quality_level() == 0);
+
+    std::cout << "  ✓ Empty contact metrics passed" << std::endl;
+}
+
+void test_populated_contact_metrics() {
+    std::cout << "Testing collision metrics with mixed contacts..." << std::endl;
+
+    Mesh mesh;
+    State state;
+    initialize_simple_mesh(mesh, state);
+
+    // Assign distinct velocities to exercise relative velocity computation.
+    state.velocities[0] = Vec3(0.0, -1.0, 0.0);
+    state.velocities[1] = Vec3(0.0, 0.25, 0.0);
+    state.velocities[2] = Vec3(0.0, -0.4, 0.0);
+    state.velocities[3] = Vec3(0.0, 0.1, 0.0);
+
+    std::vector<ContactPair> contacts;
+
+    // Point-triangle contact with mild penetration.
+    ContactPair pt;
+    pt.type = ContactType::POINT_TRIANGLE;
+    pt.idx0 = 0;
+    pt.idx1 = 1;
+    pt.idx2 = 2;
+    pt.idx3 = 3;
+    pt.gap = -5.0e-4f;
+    pt.normal = Vec3(0.0, 1.0, 0.0);
+    contacts.push_back(pt);
+
+    // Edge-edge contact that is close but not penetrating.
+    ContactPair ee;
+    ee.type = ContactType::EDGE_EDGE;
+    ee.idx0 = 0;
+    ee.idx1 = 1;
+    ee.idx2 = 2;
+    ee.idx3 = 3;
+    ee.gap = 2.0e-4f;
+    ee.normal = Vec3(0.0, 1.0, 0.0);
+    contacts.push_back(ee);
+
+    // Wall contact with a major penetration to trigger warnings.
+    ContactPair wall;
+    wall.type = ContactType::WALL;
+    wall.idx0 = 2;
+    wall.gap = -1.5e-3f;
+    wall.normal = Vec3(0.0, 1.0, 0.0);
+    contacts.push_back(wall);
+
+    const Real gap_max = 0.002f;
+    CollisionMetrics metrics = CollisionValidator::compute_metrics(
+        mesh, state, contacts, gap_max, /*ccd_enabled=*/true);
+
+    assert(metrics.num_total_contacts == 3);
+    assert(metrics.num_point_triangle == 1);
+    assert(metrics.num_edge_edge == 1);
+    assert(metrics.num_wall == 1);
+
+    assert(metrics.num_penetrations == 2);
+    assert(std::abs(metrics.max_penetration - 1.5e-3f) < 1e-6f);
+    assert(metrics.has_major_penetration);
+    assert(metrics.has_tunneling);
+
+    assert(metrics.ccd_enabled);
+    assert(metrics.num_ccd_contacts == 3);
+    assert(metrics.ccd_effectiveness > 99.0f);
+
+    assert(metrics.max_relative_velocity > 0.5f);
+    assert(metrics.avg_relative_velocity > 0.0f);
+
+    assert(metrics.quality_level() == 3);
+    assert(CollisionValidator::has_penetrations(contacts));
+    assert(std::abs(CollisionValidator::max_penetration_depth(contacts) - 1.5e-3f) < 1e-6f);
+
+    // CCD disabled should zero-out CCD metrics while keeping penetration stats.
+    CollisionMetrics metrics_no_ccd = CollisionValidator::compute_metrics(
+        mesh, state, contacts, gap_max, /*ccd_enabled=*/false);
+    assert(!metrics_no_ccd.ccd_enabled);
+    assert(metrics_no_ccd.ccd_effectiveness == 0.0f);
+    assert(metrics_no_ccd.num_ccd_contacts == 0);
+    assert(metrics_no_ccd.num_penetrations == metrics.num_penetrations);
+
+    std::cout << "  ✓ Populated contact metrics passed" << std::endl;
+}
+
+} // namespace
+
+int main() {
+    std::cout << "\n========= Collision Validator Tests =========\n" << std::endl;
+    test_empty_contact_metrics();
+    test_populated_contact_metrics();
+    std::cout << "\n========= All Collision Validator Tests Passed =========\n" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- refresh the Phase 2 roadmap items to reflect the shipped UI features
- add a regression test that exercises the collision validator metrics
- wire the new test target into the CMake test suite

## Testing
- cmake -S . -B build -DBUILD_TESTS=ON *(fails: Eigen3 not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f586dddd88832e851186d237375c49