### PR TITLE
Align barrier stiffness calculations with project spec

### DIFF
--- a/src/core/barrier.h
+++ b/src/core/barrier.h
@@ -32,7 +32,7 @@ public:
         const State& state,
         Real g_max,
         Real k_bar,
-        SparseMatrix& hessian  // Add 12×12 block
+        std::vector<Triplet>& triplets  // Append 12×12 block contributions
     );
     
     // Pin constraint derivatives: gap = ||x_i - p_target||
@@ -51,7 +51,7 @@ public:
         const State& state,
         Real g_max,
         Real k_bar,
-        SparseMatrix& hessian  // Add 3×3 block
+        std::vector<Triplet>& triplets  // Append 3×3 block
     );
     
     // Wall constraint derivatives: gap = n·x - offset
@@ -72,7 +72,7 @@ public:
         const State& state,
         Real g_max,
         Real k_bar,
-        SparseMatrix& hessian
+        std::vector<Triplet>& triplets
     );
 
 private:

--- a/src/core/stiffness.cpp
+++ b/src/core/stiffness.cpp
@@ -9,84 +9,97 @@ Real Stiffness::compute_contact_stiffness(
     Real mass,
     Real dt,
     Real gap,
+    Real g_max,
     const Vec3& normal,
     const Mat3& H_block,
-    Real gap_threshold
+    Real min_gap
 ) {
     // Base inertial term: m/Δt²
     Real k_inertial = mass / (dt * dt);
-    
+
     // Elasticity contribution: n·(H n)
-    // Ensure H is SPD first
     Mat3 H = H_block;
     enforce_spd(H);
-    
-    Vec3 Hn = H * normal;
-    Real k_elastic = normal.dot(Hn);
-    
-    // Ensure non-negative (SPD enforcement should guarantee this)
-    k_elastic = std::max(Real(0.0), k_elastic);
-    
-    // Takeover term for very small gaps: m/ĝ²
-    // This prevents unbounded stiffness as gap → 0
-    Real k_takeover = 0.0;
-    if (gap < gap_threshold && gap > 0.0) {
-        k_takeover = mass / (gap * gap);
+
+    Vec3 n = normal;
+    Real n_norm = n.norm();
+    if (n_norm > Real(1e-9)) {
+        n /= n_norm;
+    } else {
+        n = Vec3(0.0, 1.0, 0.0);
     }
-    
-    // Total stiffness with takeover
-    Real k_total = k_inertial + k_elastic + k_takeover;
-    
-    return k_total;
+
+    Vec3 Hn = H * n;
+    Real k_elastic = std::max(Real(0.0), n.dot(Hn));
+
+    // Takeover term with ĝ clamp (Section 3.3/3.4)
+    Real g_clamped = std::max(std::max(gap, min_gap), Real(1e-12));
+    Real g_hat = std::min(g_clamped, g_max);
+    Real k_takeover = mass / (g_hat * g_hat);
+
+    // Ensure takeover only active within barrier window
+    if (gap >= g_max) {
+        k_takeover = Real(0.0);
+    }
+
+    return k_inertial + k_elastic + k_takeover;
 }
 
 Real Stiffness::compute_pin_stiffness(
     Real mass,
     Real dt,
     const Vec3& offset,
-    const Mat3& H_block
+    const Mat3& H_block,
+    Real min_gap
 ) {
     // Base inertial term: m/Δt²
     Real k_inertial = mass / (dt * dt);
-    
-    // Elasticity contribution: w·(H w)
-    // where w = x - P_fixed (offset from pin target)
+
+    // Elasticity contribution along pin direction
     Mat3 H = H_block;
     enforce_spd(H);
-    
-    // Normalize offset direction
-    Vec3 w = offset;
-    Real w_norm = w.norm();
-    if (w_norm > 1e-10) {
-        w /= w_norm;
+
+    Vec3 dir = offset;
+    Real length = dir.norm();
+    if (length > Real(1e-9)) {
+        dir /= length;
     } else {
-        // If at pin position, use identity direction
-        w = Vec3(1.0, 0.0, 0.0);
+        dir = Vec3(1.0, 0.0, 0.0);
     }
-    
-    Vec3 Hw = H * w;
-    Real k_elastic = w.dot(Hw);
-    k_elastic = std::max(Real(0.0), k_elastic);
-    
-    return k_inertial + k_elastic;
+
+    Real k_elastic = std::max(Real(0.0), dir.dot(H * dir));
+
+    Real g_hat = std::max(std::max(length, min_gap), Real(1e-12));
+    Real k_takeover = mass / (g_hat * g_hat);
+
+    return k_inertial + k_elastic + k_takeover;
 }
 
 Real Stiffness::compute_wall_stiffness(
     Real mass,
-    Real gap,
+    Real wall_gap,
     const Vec3& normal,
-    const Mat3& H_block
+    const Mat3& H_block,
+    Real min_gap
 ) {
     // Wall stiffness: k = m/(g_wall)² + n·(H n)
-    Real k_inertial = mass / (gap * gap);
-    
+    Real g_hat = std::max(std::max(wall_gap, min_gap), Real(1e-12));
+    Real k_inertial = mass / (g_hat * g_hat);
+
     Mat3 H = H_block;
     enforce_spd(H);
-    
-    Vec3 Hn = H * normal;
-    Real k_elastic = normal.dot(Hn);
-    k_elastic = std::max(Real(0.0), k_elastic);
-    
+
+    Vec3 n = normal;
+    Real n_norm = n.norm();
+    if (n_norm > Real(1e-9)) {
+        n /= n_norm;
+    } else {
+        n = Vec3(0.0, 1.0, 0.0);
+    }
+
+    Vec3 Hn = H * n;
+    Real k_elastic = std::max(Real(0.0), n.dot(Hn));
+
     return k_inertial + k_elastic;
 }
 

--- a/src/core/stiffness.h
+++ b/src/core/stiffness.h
@@ -17,9 +17,10 @@ public:
         Real mass,              // Vertex or average mass
         Real dt,                // Time step
         Real gap,               // Current gap distance
+        Real g_max,             // Barrier activation distance (ĝ)
         const Vec3& normal,     // Contact normal
         const Mat3& H_block,    // Elasticity Hessian 3×3 block for this vertex
-        Real gap_threshold = 1e-4  // Threshold for takeover term
+        Real min_gap            // Numerical minimum gap
     );
     
     // Pin stiffness (Eq. 6): k_i = m_i/Δt² + w_i·(H_i w_i)
@@ -28,15 +29,17 @@ public:
         Real mass,              // Vertex mass
         Real dt,                // Time step
         const Vec3& offset,     // w_i = current_pos - pin_target
-        const Mat3& H_block     // Elasticity Hessian 3×3 block for this vertex
+        const Mat3& H_block,    // Elasticity Hessian 3×3 block for this vertex
+        Real min_gap            // Minimum separation used for takeover
     );
     
     // Wall stiffness (Eq. 7): k_wall = m_i/(g_wall)² + n_wall·(H_i n_wall)
     static Real compute_wall_stiffness(
         Real mass,              // Vertex mass
-        Real gap,               // Wall gap distance
+        Real wall_gap,          // Prescribed wall gap distance
         const Vec3& normal,     // Wall normal
-        const Mat3& H_block     // Elasticity Hessian 3×3 block for this vertex
+        const Mat3& H_block,    // Elasticity Hessian 3×3 block for this vertex
+        Real min_gap            // Minimum separation used for takeover
     );
     
     // Compute all contact stiffnesses for current constraints


### PR DESCRIPTION
## Summary
- normalize contact normals and emit barrier Hessian triplets so constraint forces assemble correctly
- implement spec-derived takeover rules in the stiffness helpers for contacts, pins, and walls
- update the integrator to use the revised stiffness APIs and accumulate barrier Hessians directly

## Testing
- ./build.sh -t *(fails: Eigen3 not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f58704b8c4832e912ac0b089f88a1a