### PR TITLE
Update stiffness tests for API changes

### DIFF
--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -17,9 +17,12 @@ using namespace ando_barrier;
 void test_stiffness_contact() {
     std::cout << "Testing contact stiffness..." << std::endl;
     Real mass = 0.1, dt = 0.01, gap = 0.001;
+    Real g_max = gap;      // Ensure takeover term inactive
+    Real min_gap = 1e-6;   // Numerical minimum gap
     Vec3 normal(0.0, 0.0, 1.0);
     Mat3 H = Mat3::Identity() * 1000.0;
-    Real k = Stiffness::compute_contact_stiffness(mass, dt, gap, normal, H);
+    Real k = Stiffness::compute_contact_stiffness(
+        mass, dt, gap, g_max, normal, H, min_gap);
     Real expected = mass / (dt * dt) + 1000.0;
     assert(std::abs(k - expected) < 1.0);
     std::cout << "  ✓ Contact stiffness passed" << std::endl;
@@ -28,10 +31,12 @@ void test_stiffness_contact() {
 void test_stiffness_pin() {
     std::cout << "Testing pin stiffness..." << std::endl;
     Real mass = 0.1, dt = 0.01;
+    Real min_gap = 1e-6;
     Vec3 offset(0.1, 0.0, 0.0);
+    Real offset_length = offset.norm();
     Mat3 H = Mat3::Identity() * 500.0;
-    Real k = Stiffness::compute_pin_stiffness(mass, dt, offset, H);
-    Real expected = mass / (dt * dt) + 500.0;
+    Real k = Stiffness::compute_pin_stiffness(mass, dt, offset, H, min_gap);
+    Real expected = mass / (dt * dt) + 500.0 + mass / (offset_length * offset_length);
     assert(std::abs(k - expected) < 1.0);
     std::cout << "  ✓ Pin stiffness passed" << std::endl;
 }
@@ -40,10 +45,14 @@ void test_stiffness_takeover() {
     std::cout << "Testing stiffness takeover..." << std::endl;
     Real mass = 0.1, dt = 0.01;
     Real gap_large = 0.01, gap_tiny = 1e-5;
+    Real g_max = 0.01;
+    Real min_gap = 1e-6;
     Vec3 normal(0.0, 0.0, 1.0);
     Mat3 H = Mat3::Identity() * 1000.0;
-    Real k_large = Stiffness::compute_contact_stiffness(mass, dt, gap_large, normal, H);
-    Real k_tiny = Stiffness::compute_contact_stiffness(mass, dt, gap_tiny, normal, H);
+    Real k_large = Stiffness::compute_contact_stiffness(
+        mass, dt, gap_large, g_max, normal, H, min_gap);
+    Real k_tiny = Stiffness::compute_contact_stiffness(
+        mass, dt, gap_tiny, g_max, normal, H, min_gap);
     assert(k_tiny > k_large * 10.0);
     std::cout << "  ✓ Stiffness takeover passed" << std::endl;
 }


### PR DESCRIPTION
## Summary
- update the basic stiffness tests to pass the new g_max and min_gap parameters required by the stiffness helpers
- adjust the pin stiffness expectation to account for the takeover term introduced by the updated API

## Testing
- cmake --build build
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68f58a718e54832ea7cc34f2cfe75388