### PR TITLE
Fix Windows demo builds by including rigid body source

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(demo_cloth_drape
     ${CMAKE_SOURCE_DIR}/src/core/pcg_solver.cpp
     ${CMAKE_SOURCE_DIR}/src/core/integrator.cpp
     ${CMAKE_SOURCE_DIR}/src/core/friction.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/rigid_body.cpp
 )
 
 target_include_directories(demo_cloth_drape PRIVATE
@@ -38,6 +39,7 @@ add_executable(demo_cloth_wall
     ${CMAKE_SOURCE_DIR}/src/core/pcg_solver.cpp
     ${CMAKE_SOURCE_DIR}/src/core/integrator.cpp
     ${CMAKE_SOURCE_DIR}/src/core/friction.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/rigid_body.cpp
 )
 
 target_include_directories(demo_cloth_wall PRIVATE


### PR DESCRIPTION
## Summary
- include the rigid body implementation in the cloth demo build targets so MSVC can resolve rigid-body symbols

## Testing
- Not run (missing Eigen in container)


------
https://chatgpt.com/codex/tasks/task_e_68f60b3985c0832eb3d49074b5b94f64