### PR TITLE
Add Blender manifest and update add-on version

### DIFF
--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Ando Barrier Physics",
     "author": "BlenderSim Project",
-    "version": (1, 0, 0),
+    "version": (1, 0, 1),
     "blender": (3, 6, 0),
     "location": "View3D > Sidebar > Ando Physics",
     "description": "Cubic Barrier with Elasticity-Inclusive Dynamic Stiffness (Ando 2024)",

--- a/blender_addon/blender_manifest.toml
+++ b/blender_addon/blender_manifest.toml
@@ -1,0 +1,15 @@
+schema_version = "1.0.0"
+
+id = "org.blendersim.ando_barrier_physics"
+version = "1.0.1"
+name = "Ando Barrier Physics"
+tagline = "Cubic Barrier with Elasticity-Inclusive Dynamic Stiffness"
+maintainer = "BlenderSim Project"
+type = "add-on"
+website = "https://github.com/Slaymish/AndoSim"
+
+blender_version_min = "3.6.0"
+
+license = ["GPL-3.0-or-later"]
+
+tags = ["Animation", "Physics", "Simulation"]


### PR DESCRIPTION
## Summary
- add a `blender_manifest.toml` file so the add-on installs through Blender's new extension manager
- bump the add-on's reported version to 1.0.1 to match the release metadata

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6d10989c0832eb54f936f40274fd6