### PR TITLE
Include manifest in release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,8 +113,9 @@ jobs:
         VERSION=${{ github.ref_name }}
         mkdir -p addon_package/ando_barrier
         
-        # Copy Python files
+        # Copy Python files and manifest
         cp blender_addon/*.py addon_package/ando_barrier/
+        cp blender_addon/blender_manifest.toml addon_package/ando_barrier/
         
         # Copy built module
         if [ "${{ runner.os }}" = "Windows" ]; then

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Ando Barrier Physics",
     "author": "BlenderSim Project",
-    "version": (1, 0, 0),
+    "version": (1, 0, 1),
     "blender": (3, 6, 0),
     "location": "View3D > Sidebar > Ando Physics",
     "description": "Cubic Barrier with Elasticity-Inclusive Dynamic Stiffness (Ando 2024)",

--- a/blender_addon/blender_manifest.toml
+++ b/blender_addon/blender_manifest.toml
@@ -1,0 +1,15 @@
+schema_version = "1.0.0"
+
+id = "org.blendersim.ando_barrier_physics"
+version = "1.0.1"
+name = "Ando Barrier Physics"
+tagline = "Cubic Barrier with Elasticity-Inclusive Dynamic Stiffness"
+maintainer = "BlenderSim Project"
+type = "add-on"
+website = "https://github.com/Slaymish/AndoSim"
+
+blender_version_min = "3.6.0"
+
+license = ["GPL-3.0-or-later"]
+
+tags = ["Animation", "Physics", "Simulation"]


### PR DESCRIPTION
## Summary
- ensure the release workflow copies blender_manifest.toml into the packaged add-on so the manifest ships with release zips

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6d10989c0832eb54f936f40274fd6