### PR TITLE
Clarify Blender compatibility for prebuilt binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Blender add-on implementing "[A Cubic Barrier with Elasticity-Inclusive Dynamic 
 **For Blender Users:**
 - Start with the [GETTING_STARTED.md](docs/GETTING_STARTED.md) guide for installation and your first viewport simulation.
 - See [BLENDER_QUICK_START.md](docs/BLENDER_QUICK_START.md) for detailed panel descriptions, scripted demos, and advanced workflows.
+- Need the prebuilt binary from CI? Those artifacts target Blender versions that ship with Python 3.11 (Blender 4.1–4.5). Older releases require rebuilding the module with Blender's bundled Python—see the compatibility table in the Getting Started guide.
 
 **For Developers:**
 - Build: `./build.sh` (requires CMake, Eigen3, pybind11)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -7,10 +7,42 @@ Welcome to **AndoSim**, a high-accuracy barrier-based physics solver that now ru
 ## 1. Requirements
 
 - **Blender** 3.6 LTS or newer (tested with Blender 4.x)
-- **Python** version that matches your Blender build (3.10 for Blender 3.6, 3.13 for Blender 4.1+)
+- **Python** version that matches your Blender build (see compatibility table below)
 - CMake + a C++17 compiler (only needed if you plan to rebuild the native `ando_barrier_core` module)
 
 > Tip: If you are using Blender from Steam or a custom install, locate the bundled Python interpreter under `<blender>/python/bin` for rebuilds.
+
+### Prebuilt Module Compatibility
+
+The GitHub Actions **build** and **release** workflows compile `ando_barrier_core` against **Python 3.11**. Use the table below to determine which Blender versions can load those prebuilt artifacts directly. For Blender releases that bundle a different Python version, rebuild the module locally with that interpreter before packaging the add-on.
+
+| Blender Version | Bundled Python | Prebuilt Artifact from CI? |
+|-----------------|----------------|----------------------------|
+| 4.5             | 3.11.11        | ✅ Works out of the box     |
+| 4.4             | 3.11.11        | ✅ Works out of the box     |
+| 4.3             | 3.11.9         | ✅ Works out of the box     |
+| 4.2             | 3.11.7         | ✅ Works out of the box     |
+| 4.1             | 3.11.6         | ✅ Works out of the box     |
+| 4.0             | 3.10.13        | ❌ Rebuild with Blender's Python |
+| 3.6 LTS         | 3.10.13        | ❌ Rebuild with Blender's Python |
+| 3.5             | 3.10.9         | ❌ Rebuild with Blender's Python |
+| 3.4             | 3.10.8         | ❌ Rebuild with Blender's Python |
+| 3.3             | 3.10.13        | ❌ Rebuild with Blender's Python |
+| 3.2             | 3.10.2         | ❌ Rebuild with Blender's Python |
+| 3.1             | 3.10.2         | ❌ Rebuild with Blender's Python |
+| 3.0             | 3.9.7          | ❌ Rebuild with Blender's Python |
+| 2.93            | 3.9.2          | ❌ Rebuild with Blender's Python |
+| 2.92            | 3.7.7          | ❌ Rebuild with Blender's Python |
+| 2.91            | 3.7.7          | ❌ Rebuild with Blender's Python |
+| 2.90            | 3.7.4          | ❌ Rebuild with Blender's Python |
+| 2.83            | 3.7.4          | ❌ Rebuild with Blender's Python |
+| 2.82            | 3.7.5          | ❌ Rebuild with Blender's Python |
+| 2.81            | 3.7.4          | ❌ Rebuild with Blender's Python |
+| 2.80            | 3.7.0          | ❌ Rebuild with Blender's Python |
+| 2.79            | 3.5.3          | ❌ Rebuild with Blender's Python |
+| 2.78            | 3.5.2          | ❌ Rebuild with Blender's Python |
+
+> When rebuilding, run `./build.sh` (or the CMake steps in the README) using Blender's bundled Python executable so the generated binary matches your target environment.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that CI build/release artifacts target Python 3.11 and Blender 4.1–4.5
- add a Blender/Python compatibility table to the Getting Started guide for users of prebuilt binaries
- mention the compatibility guidance in the README for quick reference

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f6e090dd98832e97b31c242f5a850f