### PR TITLE
Switch barrier to weak cubic form

### DIFF
--- a/src/core/barrier.cpp
+++ b/src/core/barrier.cpp
@@ -6,40 +6,28 @@
 namespace ando_barrier {
 
 Real Barrier::compute_energy(Real g, Real g_max, Real k) {
-    if (g >= g_max || g <= 0.0) return 0.0;
-    
-    // V_weak(g, ḡ, k) = -(k/2)(g-ḡ)² ln(g/ḡ)
-    Real diff = g - g_max;
-    Real g_safe = std::max(g, Real(1e-12));
-    Real ln_ratio = std::log(g_safe / g_max);
-    
-    return -0.5 * k * diff * diff * ln_ratio;
+    if (g > g_max) return 0.0;
+
+    Real diff = g_max - g;
+    return -Real(2.0 / 3.0) * k * g_max * diff * diff * diff;
 }
 
 Real Barrier::compute_gradient(Real g, Real g_max, Real k) {
-    if (g >= g_max || g <= 0.0) return 0.0;
-    
-    // d/dg V_weak = -k * (g - ḡ) * ln(g/ḡ) - k/2 * (g - ḡ)² / g
-    Real diff = g - g_max;
-    Real g_safe = std::max(g, Real(1e-12));
-    Real ln_ratio = std::log(g_safe / g_max);
-    
-    return -k * diff * ln_ratio - 0.5 * k * diff * diff / g;
+    if (g > g_max) return 0.0;
+
+    Real diff = g_max - g;
+    return k * diff * diff;
 }
 
 Real Barrier::compute_hessian(Real g, Real g_max, Real k) {
-    if (g >= g_max || g <= 0.0) return 0.0;
-    
-    // d²/dg² V_weak = -k·ln(g/ḡ) - 2k(g-ḡ)/g + (k/2)(g-ḡ)²/g²
-    Real diff = g - g_max;
-    Real g_safe = std::max(g, Real(1e-12));
-    Real ln_ratio = std::log(g_safe / g_max);
+    if (g > g_max) return 0.0;
 
-    return -k * ln_ratio - 2.0 * k * diff / g_safe + 0.5 * k * diff * diff / (g_safe * g_safe);
+    Real diff = g_max - g;
+    return -2.0 * k * diff;
 }
 
 bool Barrier::in_domain(Real g, Real g_max) {
-    return g > 0.0 && g < g_max;
+    return g <= g_max;
 }
 
 // Compute gap gradient ∂g/∂x for point-triangle contact


### PR DESCRIPTION
## Summary
- replace the logarithmic barrier evaluation with the weak cubic formulation for energy, gradient, and Hessian
- update the in-domain check to match the cubic barrier activation region

## Testing
- cmake -S . -B build *(fails: Eigen3 not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f9d0b0cae8832eb5c64f633f65d103